### PR TITLE
Add missing use statement for AnyEvent::Handle

### DIFF
--- a/v3/server/plugins/system/OVMS/Server/ApiV2.pm
+++ b/v3/server/plugins/system/OVMS/Server/ApiV2.pm
@@ -13,6 +13,7 @@ use warnings;
 use Carp;
 
 use AnyEvent;
+use AnyEvent::Handle;
 use AnyEvent::Socket;
 use AnyEvent::Log;
 use OVMS::Server::Core;


### PR DESCRIPTION
Add a use statement for AnyEvent::Handle. Without this, the module was
crashing for me with:

EV: error in callback (ignoring): Can't locate object method "new" via package "AnyEvent::Handle" at plugins/system/OVMS/Server/ApiV2.pm line 118.

I am using AnyEvent as shipped by Ubuntu in libanyevent-perl package
version 7.170-1.

Based on https://metacpan.org/pod/AnyEvent::Handle it looks like an
explicit "use" for AnyEvent::Handle is required. I don't know if this
was the case for previous versions of the AnyEvent distribution.