### PR TITLE
Add recommended plugins to config example

### DIFF
--- a/v3/server/conf/ovms_server.conf.default
+++ b/v3/server/conf/ovms_server.conf.default
@@ -27,3 +27,18 @@ sender=notifications@openvehicles.com
 
 [gcm]
 apikey=<your GCM API key, see README>
+
+[plugins]
+load=<<EOT
+VECE
+DbDBI
+AuthDrupal
+ApiV2
+Push
+PushAPNS
+PushGCM
+PushMAIL
+ApiHttp
+ApiHttpCore
+ApiHttpMqapi
+EOT


### PR DESCRIPTION
https://docs.openvehicles.com/en/latest/server/installation.html
recommends that these plugins are enabled by default. These should be in
the provided example configuration file. Otherwise, only DbDBI is loaded
and you end up with a non-functional server.