### PR TITLE
Add MariaDB socket

### DIFF
--- a/v3/server/conf/ovms_server.conf.default
+++ b/v3/server/conf/ovms_server.conf.default
@@ -3,9 +3,9 @@ path=DBI:mysql:database=openvehicles;host=127.0.0.1
 user=<put the mysql username here>
 pass=<put the mysql password here>
 
-# uncommentto connect with UNIX Socket
+# uncommentto connect with UNIX Socket and MariaDB
 # please note that you need to comment the rows above if this is used
-# path=DBI:mysql:database=openvehicles;mariadb_socket=/var/run/mysqld/mysqld.sock;
+# path=DBI:MariaDB:database=openvehicles;mariadb_socket=/var/run/mysqld/mysqld.sock;
 
 pw_encode=drupal_password($password)
 

--- a/v3/server/conf/ovms_server.conf.default
+++ b/v3/server/conf/ovms_server.conf.default
@@ -1,10 +1,11 @@
 [db]
-# connect with UNIX Socket [default]
+path=DBI:mysql:database=openvehicles;host=127.0.0.1
+user=<put the mysql username here>
+pass=<put the mysql password here>
+
+# uncommentto connect with UNIX Socket
+# please note that you need to comment the rows above if this is used
 path=DBI:mysql:database=openvehicles;mariadb_socket=/var/run/mysqld/mysqld.sock;
-# uncomment to use user/pass instead of socket
-#path=DBI:mysql:database=openvehicles;host=127.0.0.1
-#user=<put the mysql username here>
-#pass=<put the mysql password here>
 
 pw_encode=drupal_password($password)
 

--- a/v3/server/conf/ovms_server.conf.default
+++ b/v3/server/conf/ovms_server.conf.default
@@ -5,7 +5,7 @@ pass=<put the mysql password here>
 
 # uncommentto connect with UNIX Socket
 # please note that you need to comment the rows above if this is used
-path=DBI:mysql:database=openvehicles;mariadb_socket=/var/run/mysqld/mysqld.sock;
+# path=DBI:mysql:database=openvehicles;mariadb_socket=/var/run/mysqld/mysqld.sock;
 
 pw_encode=drupal_password($password)
 

--- a/v3/server/conf/ovms_server.conf.default
+++ b/v3/server/conf/ovms_server.conf.default
@@ -1,7 +1,11 @@
 [db]
-path=DBI:mysql:database=openvehicles;host=127.0.0.1
-user=<put the mysql username here>
-pass=<put the mysql password here>
+# connect with UNIX Socket [default]
+path=DBI:mysql:database=openvehicles;mariadb_socket=/var/run/mysqld/mysqld.sock;
+# uncomment to use user/pass instead of socket
+#path=DBI:mysql:database=openvehicles;host=127.0.0.1
+#user=<put the mysql username here>
+#pass=<put the mysql password here>
+
 pw_encode=drupal_password($password)
 
 # example: salting with secret salt & sha256 hashing:


### PR DESCRIPTION
Make socket the default connection method, and keep user/pass as an option.

`mysql_secure_installation` recommends using a socket instead.